### PR TITLE
Updates express API sending a response

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@
               message = message(missing);
             }
 
-            res.send(statusCode, message);
+            res.status(statusCode).send(message);
             return;
           }
         }


### PR DESCRIPTION
Hi,

I thank you very much providing `parameters-middleware`. :smiley: 

The call `res.send(statusCode, payload)` is deprecated (https://github.com/expressjs/express/issues/2227).
I just updated the API.

Kinds
Greg